### PR TITLE
Enable loading GPU-trained model on CPU

### DIFF
--- a/ael/utils.py
+++ b/ael/utils.py
@@ -60,7 +60,10 @@ def loadmodel(path, eval: bool = True) -> nn.ModuleDict:
     Evaluation mode is needed to switch off the dropout layers when using the model
     for inference.
     """
-    d = torch.load(path)
+    if torch.cuda.is_available():
+        d = torch.load(path)
+    else:
+        d = torch.load(path, map_location=torch.device('cpu'))
 
     model = models.AffinityModel(**d["args"])
 
@@ -124,7 +127,10 @@ def loadAEVC(path) -> torchani.AEVComputer:
     torchani.AEVComputer
         AEVComputer
     """
-    d = torch.load(path)
+    if torch.cuda.is_available():
+        d = torch.load(path)
+    else:
+        d = torch.load(path, map_location=torch.device('cpu'))
 
     AEVC = torchani.AEVComputer(**d["args"])
 


### PR DESCRIPTION
GPU-trained models can't be loaded directly to the CPU. 

```
RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. 
If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.
```

If `torch.cuda.is_available() == False`, `map_location=torch.device('cpu')` is used in order to enable loading a GPU-trained model on the CPU (for inference).