### PR TITLE
Fix protein chain in visualization output

### DIFF
--- a/ael/loaders.py
+++ b/ael/loaders.py
@@ -37,7 +37,8 @@ def _universe_from_openbabel(obmol):
     u.add_TopologyAttr("resnum", [1] * n_residues)
     u.add_TopologyAttr("resid", [1] * n_residues)
     u.add_TopologyAttr("resname", ["LIG"] * n_residues)
-    u.add_TopologyAttr("record_types", ["HETATM"] * len(elements))
+    u.add_TopologyAttr("record_types", ["HETATM"] * n_atoms)
+    u.add_TopologyAttr("segid", [""] * n_residues)
 
     u.atoms.positions = coordinates
 

--- a/tests/loaders_test.py
+++ b/tests/loaders_test.py
@@ -39,6 +39,7 @@ def test_load_mols(testdir, system, n_ligand, n_receptor, ext):
     assert set(lig.resnums) == set([1])
     assert set(lig.resids) == set([1])
     assert set(lig.record_types) == set(["HETATM"])
+    assert set(lig.segids) == set([""])
 
 
 def test_load_mols_fail_lig(testdir):


### PR DESCRIPTION
PDB files from visualization (PR #19)  were missing chain information, preventing PyMol to correctly render the secondary structure. This happened because the unified molecular input introduced in #18 needs the ligand universe to have all topology attributes set when merging with the protein universe and `segid` was not set (`segid` is the chain ID, not `chainID`...). 

This PR sets the `segid` of the ligand to `Z`, so that protein chain IDs are retained in the output.