### PR TITLE
Gradient of the output

### DIFF
--- a/ael/grad.py
+++ b/ael/grad.py
@@ -1,10 +1,9 @@
 import torch
-from torch import nn
 
 
-def gradient(species, coordinates, label, model, AEVC, loss, device=None):
+def gradient(species, coordinates, model, AEVC, device=None):
     """
-    Compute gradient of the loss with respect to atomic coordinates.
+    Compute gradient of the output with respect to atomic coordinates.
 
     Parameters
     ----------
@@ -33,7 +32,6 @@ def gradient(species, coordinates, label, model, AEVC, loss, device=None):
         device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
     # Move data to device and add batch dimension
-    label = torch.tensor(label).to(device).unsqueeze(0)
     species = species.to(device).unsqueeze(0)
     coordinates = (
         coordinates.clone().detach().requires_grad_(True).to(device).unsqueeze(0)
@@ -42,10 +40,6 @@ def gradient(species, coordinates, label, model, AEVC, loss, device=None):
     aevs = AEVC.forward((species, coordinates)).aevs
 
     output = model(species, aevs)
-
-    #ls = loss(output, label)
-    # Compute gradient of the loss with respect to the coordinates
-    #grad = torch.autograd.grad(ls, coordinates)[0]
 
     # Compute gradient of the output with respect to the coordinates
     grad = torch.autograd.grad(output, coordinates)[0]
@@ -213,10 +207,8 @@ if __name__ == "__main__":
                 gradt = gradient(
                     torch.from_numpy(species),
                     torch.from_numpy(coordinates),
-                    float(label),
                     model,
                     AEVC,
-                    nn.MSELoss(),
                     device=args.device,
                 )
 

--- a/ael/grad.py
+++ b/ael/grad.py
@@ -43,10 +43,12 @@ def gradient(species, coordinates, label, model, AEVC, loss, device=None):
 
     output = model(species, aevs)
 
-    ls = loss(output, label)
-
+    #ls = loss(output, label)
     # Compute gradient of the loss with respect to the coordinates
-    grad = torch.autograd.grad(ls, coordinates)[0]
+    #grad = torch.autograd.grad(ls, coordinates)[0]
+
+    # Compute gradient of the output with respect to the coordinates
+    grad = torch.autograd.grad(output, coordinates)[0]
 
     # Remove batch dimension
     return grad.squeeze(0)

--- a/ael/loaders.py
+++ b/ael/loaders.py
@@ -389,14 +389,14 @@ anum_to_idx = np.vectorize(_anum_to_idx)
 
 
 def chemap(
-    atomicnums: List[np.ndarray], cmap: Union[Dict[str, str], Dict[str, List[str]]]
+    atomicnums: List[torch.Tensor], cmap: Union[Dict[str, str], Dict[str, List[str]]]
 ):
     """
     Map chemical elements into another.
 
     Parameters
     ----------
-    atomicnum: List[np.ndarray]
+    atomicnum: List[torch.Tensor]
         List of atomic numbers for every system
     chemap: Union[Dict[str, str],Dict[str, List[str]]
         Chemical mapping
@@ -631,8 +631,8 @@ class PDBData(Data):
 
                 atomicnums = elements_to_atomicnums(els)
 
-                # Species are converted to tensors in _atomicnums_to_idx
-                # Species are transformed to 0-based indices in _atomicnums_to_idx
+                # Species are converted to tensors in atomicnums_to_idx
+                # Species are transformed to 0-based indices in atomicnums_to_idx
                 self.species.append(atomicnums)
 
                 # Coordinates are transformed to tensor here and left unchanged
@@ -782,8 +782,8 @@ class VSData(Data):
 
                     atomicnums = elements_to_atomicnums(els)
 
-                    # Species are converted to tensors in _atomicnums_to_idx
-                    # Species are transformed to 0-based indices in _atomicnums_to_idx
+                    # Species are converted to tensors in atomicnums_to_idx
+                    # Species are transformed to 0-based indices in atomicnums_to_idx
                     self.species.append(atomicnums)
 
                     # Coordinates are transformed to tensor here and left unchanged

--- a/tests/test_grad.py
+++ b/tests/test_grad.py
@@ -2,7 +2,6 @@ import mlflow
 import numpy as np
 import torch
 import torchani
-from torch import nn
 
 from ael import grad, loaders, models
 
@@ -53,7 +52,6 @@ def test_grad(testdata, testdir):
         assert AEVC.aev_length == 20
 
         model = models.AffinityModel(n_species, AEVC.aev_length)
-        loss = nn.MSELoss()
 
         # Move model and AEVComputer to device
         model.to(device)
@@ -63,11 +61,9 @@ def test_grad(testdata, testdir):
         model.eval()
 
         for i in range(n_systems):
-            pdbid, label, (species, coordinates) = data[i]
+            pdbid, _, (species, coordinates) = data[i]
 
-            gradient = grad.gradient(
-                species, coordinates, label, model, AEVC, loss, device
-            )
+            gradient = grad.gradient(species, coordinates, model, AEVC, device)
 
             assert gradient.shape == coordinates.shape
 


### PR DESCRIPTION
Computing the gradient of the output (with respect to atomic coordinates) makes more sense than computing the gradient of the loss, since the latter is only available when the correct answer is known.

The gradient of the output with respect to atomic coordinates indicates how the model would increase the binding affinity.